### PR TITLE
CC-136 Token exchange and ENV_VARS

### DIFF
--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -17,8 +17,20 @@ export default function (ctx, inject) {
   options.strategies.map(strategy => {
     const scheme = 'scheme_' + hash(options.strategyScheme.get(strategy))
     const schemeOptions = JSON.stringify(strategy)
+
+    const schemeOptionsFromEnv = Object.keys(strategy).reduce((agg, key) => {
+      if (typeof strategy[key] !== 'string') return agg
+      const match = strategy[key].match(/process.env.(.+)/)
+      if (!match) return agg
+      agg.push(`${key}: ctx.app.$env.${match[1]}`)
+      return agg
+    }, [])
+
     const name = strategy._name
-    return `// ${name}\n  $auth.registerStrategy('${name}', new ${scheme}($auth, ${schemeOptions}))`
+    return `// ${name}\n  $auth.registerStrategy('${name}', new ${scheme}($auth, {
+      ...${schemeOptions},
+      ...{${schemeOptionsFromEnv.join(', ')}}
+    }))`
   }).join('\n\n  ')
   %>
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -123,6 +123,10 @@ export default class Oauth2Scheme {
     this.$auth.setUser(user)
   }
 
+  async _beforeRedirect () {
+    return true
+  }
+
   async _handleCallback (uri) {
     // Handle callback only for specified route
     if (this.$auth.options.redirect && this.$auth.ctx.route.path !== this.$auth.options.redirect.callback) {
@@ -172,6 +176,8 @@ export default class Oauth2Scheme {
       }
     }
 
+    const rawToken = token
+
     if (!token || !token.length) {
       return
     }
@@ -192,6 +198,8 @@ export default class Oauth2Scheme {
       refreshToken = this.options.token_type + ' ' + refreshToken
       this.$auth.setRefreshToken(this.name, refreshToken)
     }
+
+    await this._beforeRedirect(rawToken)
 
     // Redirect to home
     this.$auth.redirect('home', true)

--- a/lib/schemes/oauth2TokenExchange.js
+++ b/lib/schemes/oauth2TokenExchange.js
@@ -21,7 +21,5 @@ export default class TokenExchangeScheme extends Oauth2Scheme {
     this.$auth.setToken('local', 'Bearer ' + data.access_token)
     await this.$auth.setStrategy('local')
     await this.$auth.fetchUser()
-    // this.$auth.redirect = redirect.bind(this.$auth) // Rebind auth function to incorporate google auth changes
-    this.$auth.redirect('home', true)
   }
 }

--- a/lib/schemes/oauth2TokenExchange.js
+++ b/lib/schemes/oauth2TokenExchange.js
@@ -1,0 +1,27 @@
+import { get } from 'lodash'
+import Oauth2Scheme from './oauth2'
+
+export default class TokenExchangeScheme extends Oauth2Scheme {
+  async _beforeRedirect (token) {
+    const url = '/api/auth/social-auth'
+    const data = await this.$auth.ctx.app.$axios.$post(url, {
+      provider: this.name,
+      token
+    }).catch(async (e) => {
+      await this.$auth.logout()
+      // Ideally change this back to this.$auth.redirect('home', true) but trigger something in the store to raise a 'toast' or an exception
+      const errorKey = get(e.response, 'data.error_description')
+      // eslint-disable-next-line no-console
+      console.error('Error during social-auth', errorKey, e)
+      window.location.replace(
+        this.$auth.options.redirect.login + `?error=${this.name}-no-account`
+      )
+    })
+    this.$auth.setRefreshToken('local', data.refresh_token)
+    this.$auth.setToken('local', 'Bearer ' + data.access_token)
+    await this.$auth.setStrategy('local')
+    await this.$auth.fetchUser()
+    // this.$auth.redirect = redirect.bind(this.$auth) // Rebind auth function to incorporate google auth changes
+    this.$auth.redirect('home', true)
+  }
+}


### PR DESCRIPTION
Changes needed to the nuxt auth package to facilitate the federated auth in Croud Control

## Schemes
### oAuth2
Update the oAuth2 scheme class to call a `_beforeRedirect` method to allow for custom functionality before the redirect

### oAuth2TokenExchange
Add's new scheme file that extends the `oAuth2` scheme and uses the new `_beforeRedirect` method to handle the token exchange with ID4

We can use the new scheme by defining it in the auth strategies section of the `nuxt.config.js`
```js
google: {
  _scheme: 'oauth2TokenExchange'
}
```

## ENV_VARs at Runtime
### Changes
This Nuxt module will now build the plugin in such a way that any strategy option prepended with `process.env.` will be evaluated at runtime and not buildtime, allowing for a single container to work in multiple environments

### Proposed Usage
Ensure we are exposing the ENV_VAR through the nuxt-env module and use a prepended string to describe the ENV_VAR we want to use for a certain strategy option.
```js
modules: [
  ['nuxt-env', { keys: ['GOOGLE_AUTH_CLIENT_ID'] }]
],

auth: {
  strategies: {
    google: {
      client_id: 'process.env.GOOGLE_AUTH_CLIENT_ID'
    }
  }
}
```

