### PR TITLE
Logout before exchange

### DIFF
--- a/lib/schemes/oauth2TokenExchange.js
+++ b/lib/schemes/oauth2TokenExchange.js
@@ -19,6 +19,10 @@ export default class TokenExchangeScheme extends Oauth2Scheme {
     })
     this.$auth.setRefreshToken('local', data.refresh_token)
     this.$auth.setToken('local', 'Bearer ' + data.access_token)
+
+    // logout of the oAuth2 scheme before switching to local
+    this.$auth.logout()
+
     await this.$auth.setStrategy('local')
     await this.$auth.fetchUser()
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@croudtech/auth",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "Authentication module for Nuxt.js",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
As discussed on the chat, this logs the user out of the 'google' strategy before setting the current strategy to local.

This will prevent being logged in to multiple strategies at once and will better handle token expiry and logging out.