### PR TITLE
CC-436 Handle refresh tokens in local strategy

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -43,12 +43,20 @@ export default class LocalScheme {
     )
 
     if (this.options.tokenRequired) {
+      const accessTokenKey = this.options.accessTokenKey || 'access_token'
+      const refreshTokenKey = this.options.refreshTokenKey || 'refresh_token'
+
       const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + result
+        ? this.options.tokenType + ' ' + result[accessTokenKey]
         : result
 
       this.$auth.setToken(this.name, token)
       this._setToken(token)
+
+      if (this.options.refreshToken) {
+        const refreshToken = result[refreshTokenKey]
+        this.$auth.setRefreshToken(this.name, refreshToken)
+      }
     }
 
     return this.fetchUser()
@@ -120,6 +128,7 @@ export default class LocalScheme {
 
 const DEFAULTS = {
   tokenRequired: true,
+  refreshToken: false,
   tokenType: 'Bearer',
   globalToken: true,
   tokenName: 'Authorization'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@croudtech/auth",
-  "version": "4.8.7",
+  "version": "4.8.8",
   "description": "Authentication module for Nuxt.js",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
The default local strategy doesn't handle refresh tokens
Add logic to set the refresh token from the password grant