### PR TITLE
Router base issue

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -129,7 +129,7 @@ export default class Oauth2Scheme {
 
   async _handleCallback (uri) {
     // Handle callback only for specified route
-    if (this.$auth.options.redirect && this.$auth.ctx.route.path !== this.$auth.options.redirect.callback) {
+    if (this.$auth.options.redirect && this.$auth.ctx.route.path !== this.$auth.options.redirect.callback && !this.$auth.ctx.base) {
       return
     }
     // Callback flow is not supported in server side

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@croudtech/auth",
-  "version": "4.8.8",
+  "version": "4.9.0",
   "description": "Authentication module for Nuxt.js",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
There is an issue with this if statement when setting a Nuxt Router base url.
`this.$auth.ctx.route.path` is a relative path that doesn't include the base
`this.$auth.options.redirect.callback` is a relative path that does include the base

Though in prod, the main SPA will be handling auth, so this is just for the dev env and shouldn't compromise anything in production.
